### PR TITLE
Update readme with minimal workflow example

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ This github action will add the `staging` label to any pull request that is merg
 
 To make use of this action in your repository, you will need to setup a workflow like the one below.
 
-```
-name: Testing Staging Label
+```yaml
+name: Staging Label
 
 # This action needs to run on push
 on: [push]
@@ -16,28 +16,11 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v3
-      - name: Staging label
+      - uses: planningcenter/staging-label-action@v0.6.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: planningcenter/staging-label-action@v0.1.1
-```
-
-If you find that this action can be a bit slow, you may be able to speed it up by using [setup-node](https://github.com/actions/setup-node). Add this to your workflow:
-
-```
-steps:
-  - uses: actions/checkout@v3
-  - uses: actions/setup-node@v3
-    with:
-      node-version: '12'
-      cache: 'npm'
-  - name: Staging label
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    uses: planningcenter/staging-label-action@v0.1.1
+        
 ```
 
 ## Copyright & License


### PR DESCRIPTION
After using this in an app, I found that there were a few parts of this readme that had gone a bit out of date. 

1. The actions/checkout step isn't needed at all since everything happens with GitHub API calls
2. The setup-node step shouldn't need to be suggested now that the action is being packaged up by ncc with all of its dependencies
3. Update the version for this action to point to the most recent tag